### PR TITLE
fix camera_info tf

### DIFF
--- a/config/depth_image_creator.rviz
+++ b/config/depth_image_creator.rviz
@@ -9,6 +9,7 @@ Panels:
         - /Grid1/Offset1
         - /PointCloud21
         - /depth_image_creator1
+        - /TF1
         - /TF1/Frames1
         - /TF1/Tree1
         - /CameraInfo1
@@ -130,7 +131,7 @@ Visualization Manager:
       Enabled: true
       Image Topic: ""
       Name: CameraInfo
-      Topic: /zed/left/camera_info_raw
+      Topic: /zed/left/camera_info_new
       Unreliable: false
       Value: true
       alpha: 0.5
@@ -166,7 +167,7 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/XYOrbit
-      Distance: 13.8095121
+      Distance: 3.84596205
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.0599999987
         Stereo Focal Distance: 1
@@ -181,10 +182,10 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.00999999978
-      Pitch: 0.29039821
+      Pitch: 0.130398154
       Target Frame: <Fixed Frame>
       Value: XYOrbit (rviz)
-      Yaw: 3.85538507
+      Yaw: 3.16538453
     Saved: ~
 Window Geometry:
   Displays:

--- a/launch/depth_image_creator.launch
+++ b/launch/depth_image_creator.launch
@@ -1,11 +1,16 @@
 <launch>
 
+  <arg name="gui" default="true" />
+
+  <!-- camera_info_publisher -->
+  <node pkg="pcl_processing" name="camera_info_publisher" type="camera_info_publisher" output="screen" />
+
   <!-- depth_image_creator -->
   <node name="depth_image_creator"
         pkg="nodelet" type="nodelet"
         args="standalone jsk_pcl/DepthImageCreator">
     <remap from="~input" to="/zed/point_cloud/cloud_registered" />
-    <remap from="~info" to="/zed/left/camera_info_raw" />
+    <remap from="~info" to="/zed/left/camera_info_new" />
     <rosparam>
       use_approximate: true
       max_queue_size: 3
@@ -15,7 +20,12 @@
   </node>
 
   <!-- <node pkg="tf2_ros" type="static_transform_publisher" name="bridge_zed-left-camera_to_camera-info" args="0 0 0 0 0 0 1 zed_left_camera esr_1" /> -\-> -->
-  
-  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find pcl_processing)/config/depth_image_creator.rviz" required="true" />
-  
+
+  <group if="$(arg gui)">
+    <node name="rviz"
+          pkg="rviz" type="rviz"
+          args="-d $(find pcl_processing)/config/depth_image_creator.rviz">
+    </node>
+  </group>
+
 </launch>

--- a/scripts/camera_info_publisher
+++ b/scripts/camera_info_publisher
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import rospy
+from sensor_msgs.msg import CameraInfo
+
+class CameraInfoPublisher:
+
+    def __init__(self):
+        rospy.init_node('camera_info_publisher', anonymous=False)
+        rospy.Subscriber('/zed/left/camera_info_raw', CameraInfo, self.oldInfo)
+
+    def oldInfo(self, _oldInfo):
+        _oldInfo.header.frame_id = "zed_depth_camera"
+        pub = rospy.Publisher('/zed/left/camera_info_new', CameraInfo, queue_size=10)
+        pub.publish(_oldInfo)
+
+if __name__ == '__main__':
+    try:
+        Publisher = CameraInfoPublisher()
+        rospy.spin()
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
depth_image_createrのcamera_infoの方向を修正しました。
具体的にはcamera_infoの親frameをzed_left_cameraからzed_depth_cameraに変更し、depth_image_createrのnodeの入力のtopicもそれに伴い変更
rvizのviewも新しいtopicに変更しました。